### PR TITLE
避免 chaifen.csv 重复下载以及不必要的下载

### DIFF
--- a/src/.vitepress/config.mts
+++ b/src/.vitepress/config.mts
@@ -21,8 +21,7 @@ export default defineConfig({
     }
   },
   head: [
-    ['link', { rel: 'icon', href: '/logo_blue.png', type: 'image/png' }],
-    ['link', { rel: 'preload', href: '/chaifen.csv', as: 'fetch' }]
+    ['link', { rel: 'icon', href: '/logo_blue.png', type: 'image/png' }]
   ],
   vite: {
     css: {


### PR DESCRIPTION
当 web browser 中缓存失效或者没有缓存时，这个 preload 与拆分查询的 Vue component 都会去下载 chaifen.csv，由于这个文件有 2.3MB 下载比较慢，导致 Vue component 的 async fetch 没能享受 link preload 的好处，就会重复下载 chaifen.csv。

另外，在所有页面都 preload chaifen.csv 显然是没必要的，绝大部分页面仅仅是文档。

感谢 QQ 网友「玓(dì)瓅(lì)」一起调查，是他发现这个 link preload 的问题。