### PR TITLE
将页内导航总是显示在顶部以方便宽表展示

### DIFF
--- a/src/docs/statistics.md
+++ b/src/docs/statistics.md
@@ -1,3 +1,21 @@
+---
+aside: false
+---
+
+<style>
+/* override https://github.com/vuejs/vitepress/blob/v1.5.0/src/client/theme-default/components/VPLocalNav.vue#L113 */
+.VPLocalNav {
+    display: block !important;
+}
+
+/* override https://github.com/vuejs/vitepress/blob/v1.5.0/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue#L164 */
+@media (min-width: 961px) {
+  .items {
+    left: calc((100vw - var(--vp-layout-max-width)) / 2 + var(--vp-sidebar-width) + 32px) !important;
+  }
+}
+</style>
+
 # 常见输入法测评数据
 
 梦泽闲客 更新于二零二四年五月七日

--- a/src/zht/docs/statistics.md
+++ b/src/zht/docs/statistics.md
@@ -1,3 +1,21 @@
+---
+aside: false
+---
+
+<style>
+/* override https://github.com/vuejs/vitepress/blob/v1.5.0/src/client/theme-default/components/VPLocalNav.vue#L113 */
+.VPLocalNav {
+    display: block !important;
+}
+
+/* override https://github.com/vuejs/vitepress/blob/v1.5.0/src/client/theme-default/components/VPLocalNavOutlineDropdown.vue#L164 */
+@media (min-width: 961px) {
+  .items {
+    left: calc((100vw - var(--vp-layout-max-width)) / 2 + var(--vp-sidebar-width) + 32px) !important;
+  }
+}
+</style>
+
 # 常見輸入法測評數據
 
 夢澤閒客 更新於二零二四年五月七日


### PR DESCRIPTION
只影响 PC 的这个 statistics 页面，效果如图：

修改前：

![e4a327eafed355841bdc3e38218e7d79](https://github.com/user-attachments/assets/07118d0e-1a96-4bb5-8572-12bbedb52129)

修改后：

![29a9f623eb9a110334d07458e422c8b2](https://github.com/user-attachments/assets/e5c0b48e-3a50-47fd-9a3d-28cfd9b0e85e)
